### PR TITLE
EDK2-Test BUG4244 V2 - Print PCIe device path for SCT failures.

### DIFF
--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestConformance.c
@@ -93,7 +93,7 @@ BBTestGetInformationConformanceTest (
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
   EFI_STATUS                            Status;
   EFI_ADAPTER_INFORMATION_PROTOCOL      *AdapterInfo;
-
+  UINT16                                *DevicePathStr;
   //
   // init
   //
@@ -110,7 +110,13 @@ BBTestGetInformationConformanceTest (
   if ( EFI_ERROR(Status) ) {
     return Status;
   }
-
+  DevicePathStr = SctDevicePathStrFromProtocol (AdapterInfo, &gEfiAdapterInformationProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   //Call check points
   //
@@ -137,6 +143,7 @@ BBTestSetInformationConformanceTest (
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
   EFI_STATUS                            Status;
   EFI_ADAPTER_INFORMATION_PROTOCOL      *AdapterInfo;
+  UINT16                                *DevicePathStr;
                                         
   //
   // init
@@ -154,7 +161,13 @@ BBTestSetInformationConformanceTest (
   if ( EFI_ERROR(Status) ) {
     return Status;
   }
-
+  DevicePathStr = SctDevicePathStrFromProtocol (AdapterInfo, &gEfiAdapterInformationProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   //Call check points
   //
@@ -178,6 +191,7 @@ BBTestGetSupportedTypesConformanceTest (
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
   EFI_STATUS                            Status;
   EFI_ADAPTER_INFORMATION_PROTOCOL      *AdapterInfo;
+  UINT16                                *DevicePathStr;
                                         
   //
   // init
@@ -195,7 +209,13 @@ BBTestGetSupportedTypesConformanceTest (
   if ( EFI_ERROR(Status) ) {
     return Status;
   }
-
+  DevicePathStr = SctDevicePathStrFromProtocol (AdapterInfo, &gEfiAdapterInformationProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   //Call check points
   //

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoBBTestFunction.c
@@ -68,7 +68,7 @@ BBTestGetInformationFunctionTest (
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
   EFI_STATUS                            Status;
   EFI_ADAPTER_INFORMATION_PROTOCOL      *AdapterInfo;
-
+  UINT16                                *DevicePathStr;
   //
   // init
   //
@@ -85,7 +85,13 @@ BBTestGetInformationFunctionTest (
   if ( EFI_ERROR(Status) ) {
     return Status;
   }
-
+  DevicePathStr = SctDevicePathStrFromProtocol (AdapterInfo, &gEfiAdapterInformationProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   //Call check points
   //
@@ -108,7 +114,7 @@ BBTestSetInformationFunctionTest (
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
   EFI_STATUS                            Status;
   EFI_ADAPTER_INFORMATION_PROTOCOL      *AdapterInfo;
-
+  UINT16                                *DevicePathStr;
   //
   // init
   //
@@ -125,7 +131,13 @@ BBTestSetInformationFunctionTest (
   if ( EFI_ERROR(Status) ) {
     return Status;
   }
-
+  DevicePathStr = SctDevicePathStrFromProtocol (AdapterInfo, &gEfiAdapterInformationProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   //Call check points
   //
@@ -147,7 +159,7 @@ BBTestGetSupportedTypesFunctionTest (
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
   EFI_STATUS                            Status;
   EFI_ADAPTER_INFORMATION_PROTOCOL      *AdapterInfo;
-  
+  UINT16                                *DevicePathStr;
 
   //
   // init
@@ -165,7 +177,13 @@ BBTestGetSupportedTypesFunctionTest (
   if ( EFI_ERROR(Status) ) {
     return Status;
   }
-
+  DevicePathStr = SctDevicePathStrFromProtocol (AdapterInfo, &gEfiAdapterInformationProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   //Call check points
   //

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoProtocolBBTest.inf
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/AdapterInfo/BlackBoxTest/AdapterInfoProtocolBBTest.inf
@@ -49,3 +49,4 @@
   EfiTestLib
 
 [Protocols]
+  gEfiAdapterInformationProtocolGuid

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigAccess/BlackBoxTest/HIIConfigAccessBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigAccess/BlackBoxTest/HIIConfigAccessBBTestConformance.c
@@ -120,7 +120,7 @@ BBTestExtractConfigConformanceTest (
   EFI_STATUS                            Status;
   EFI_HII_CONFIG_ACCESS_PROTOCOL        *HIIConfigAccess;
   EFI_HII_CONFIG_ROUTING_PROTOCOL       *HIIConfigRouting;
-  
+  UINT16                                *DevicePathStr;
   //
   // init
   //
@@ -137,7 +137,13 @@ BBTestExtractConfigConformanceTest (
   if (EFI_ERROR(Status)) {
     return Status;
   }
-
+  DevicePathStr = SctDevicePathStrFromProtocol (HIIConfigAccess, &gBlackBoxEfiHIIConfigAccessProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Get the Config Routing Protocol Interface
   //
@@ -170,7 +176,7 @@ BBTestRouteConfigConformanceTest (
   EFI_STATUS                            Status;
   EFI_HII_CONFIG_ACCESS_PROTOCOL        *HIIConfigAccess;
   EFI_HII_CONFIG_ROUTING_PROTOCOL       *HIIConfigRouting;
-  
+  UINT16                                *DevicePathStr;
   //
   // init
   //
@@ -187,7 +193,13 @@ BBTestRouteConfigConformanceTest (
   if (EFI_ERROR(Status)) {
     return Status;
   }
-
+  DevicePathStr = SctDevicePathStrFromProtocol (HIIConfigAccess, &gBlackBoxEfiHIIConfigAccessProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Get the Config Routing Protocol Interface
   //

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigAccess/BlackBoxTest/HIIConfigAccessBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/HIIConfigAccess/BlackBoxTest/HIIConfigAccessBBTestFunction.c
@@ -124,7 +124,7 @@ BBTestExtractConfigFunctionTest (
   EFI_STATUS                            Status;
   EFI_HII_CONFIG_ACCESS_PROTOCOL        *HIIConfigAccess;
   EFI_HII_CONFIG_ROUTING_PROTOCOL       *HIIConfigRouting;
-  
+  UINT16                                *DevicePathStr;
   //
   // init
   //
@@ -141,7 +141,13 @@ BBTestExtractConfigFunctionTest (
   if (EFI_ERROR(Status)) {
     return Status;
   }
-
+  DevicePathStr = SctDevicePathStrFromProtocol (HIIConfigAccess, &gBlackBoxEfiHIIConfigAccessProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Get the Config Routing Protocol Interface
   //
@@ -173,7 +179,7 @@ BBTestRouteConfigFunctionTest (
   EFI_STATUS                            Status;
   EFI_HII_CONFIG_ACCESS_PROTOCOL        *HIIConfigAccess;
   EFI_HII_CONFIG_ROUTING_PROTOCOL       *HIIConfigRouting;
-
+  UINT16                                *DevicePathStr;
   //
   // init
   //
@@ -190,7 +196,13 @@ BBTestRouteConfigFunctionTest (
   if (EFI_ERROR(Status)) {
     return Status;
   }
-  
+  DevicePathStr = SctDevicePathStrFromProtocol (HIIConfigAccess, &gBlackBoxEfiHIIConfigAccessProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Get the Config Routing Protocol Interface
   //

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/PxeBaseCode/BlackBoxTest/PxeBaseCodeBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/PxeBaseCode/BlackBoxTest/PxeBaseCodeBBTestConformance.c
@@ -50,7 +50,7 @@ BBTestNewStartConformanceTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
-
+  UINT16                                *DevicePathStr;
   //
   // Get the Standard Library Interface
   //
@@ -68,6 +68,13 @@ BBTestNewStartConformanceTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Disable EFI_PXE_BASE_CODE_PROTOCOL Protocol interface
@@ -237,6 +244,7 @@ BBTestNewStopConformanceTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -255,6 +263,13 @@ BBTestNewStopConformanceTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Disable EFI_PXE_BASE_CODE_PROTOCOL Protocol interface
@@ -418,6 +433,7 @@ BBTestStartConformanceTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -436,6 +452,13 @@ BBTestStartConformanceTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Change EFI_PXE_BASE_CODE_PROTOCOL Protocol state to enabled
@@ -522,6 +545,7 @@ BBTestStopConformanceTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -540,6 +564,13 @@ BBTestStopConformanceTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Make sure the EFI_PXE_BASE_CODE_PROTOCOL Protocol is disabled
@@ -606,6 +637,7 @@ BBTestDhcpConformanceTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -624,6 +656,13 @@ BBTestDhcpConformanceTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Change EFI_PXE_BASE_CODE_PROTOCOL Protocol to disabled
@@ -791,6 +830,7 @@ BBTestDiscoverConformanceTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -809,6 +849,13 @@ BBTestDiscoverConformanceTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Change EFI_PXE_BASE_CODE_PROTOCOL Protocol to disabled
@@ -988,6 +1035,7 @@ BBTestMtftpConformanceTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   UINTN                                 BlockSize=512;
   EFI_IP_ADDRESS                        ServerIp;
   CHAR8                                 *FileName;
@@ -1013,6 +1061,13 @@ BBTestMtftpConformanceTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Fill Parameters (ServerIp, FileName, BufferPtr)
@@ -1473,6 +1528,7 @@ BBTestUdpWriteConformanceTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   EFI_IP_ADDRESS                        DestIp;
   EFI_PXE_BASE_CODE_UDP_PORT            DestPort;
   UINTN                                 BufferSize;
@@ -1501,6 +1557,13 @@ BBTestUdpWriteConformanceTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   // Disable EFI_PXE_BASE_CODE_PROTOCOL protocol if needed
   Status = ChangePxeState (BcInterface, FALSE, BcInterface->Mode->Started, FALSE);
@@ -1689,6 +1752,7 @@ BBTestUdpReadConformanceTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   UINT16                                OpFlags;
   UINTN                                 BufferSize;
   VOID                                  *BufferPtr;
@@ -1713,6 +1777,13 @@ BBTestUdpReadConformanceTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   // Malloc for data
   BufferSize = MAX_UDP_SIZE;
@@ -2004,6 +2075,7 @@ BBTestSetIpFilterConformanceTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   EFI_PXE_BASE_CODE_IP_FILTER           BcIpFilter;
 
   //
@@ -2023,6 +2095,13 @@ BBTestSetIpFilterConformanceTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   // Disable EFI_PXE_BASE_CODE_PROTOCOL protocol if needed
   Status = ChangePxeState (BcInterface, FALSE, BcInterface->Mode->Started, FALSE);
@@ -2084,6 +2163,7 @@ BBTestArpConformanceAutoTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   EFI_IP_ADDRESS                        IpAddr;
 
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
@@ -2110,7 +2190,13 @@ BBTestArpConformanceAutoTest (
                    );
     return Status;
   }
-
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Disable EFI_PXE_BASE_CODE_PROTOCOL Protocol interface
   //
@@ -2232,6 +2318,7 @@ BBTestArpConformanceManualTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   EFI_IP_ADDRESS                        IpAddr;
   EFI_MAC_ADDRESS                       MacAddr;
   EFI_INI_FILE_HANDLE                   FileHandle;
@@ -2263,6 +2350,13 @@ BBTestArpConformanceManualTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   // Disable EFI_PXE_BASE_CODE_PROTOCOL protocol if needed
   Status = ChangePxeState (BcInterface, FALSE, BcInterface->Mode->Started, FALSE);
@@ -2452,6 +2546,7 @@ BBTestSetParametersConformanceTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -2470,6 +2565,13 @@ BBTestSetParametersConformanceTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   // Disable EFI_PXE_BASE_CODE_PROTOCOL protocol if needed
   Status = ChangePxeState (BcInterface, FALSE, BcInterface->Mode->Started, FALSE);
@@ -2531,6 +2633,7 @@ BBTestSetStationIpConformanceTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -2549,6 +2652,13 @@ BBTestSetStationIpConformanceTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   // Disable EFI_PXE_BASE_CODE_PROTOCOL protocol if needed
   Status = ChangePxeState (BcInterface, FALSE, BcInterface->Mode->Started, FALSE);
@@ -2603,6 +2713,7 @@ BBTestSetPacketsConformanceTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -2621,6 +2732,13 @@ BBTestSetPacketsConformanceTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   // Disable EFI_PXE_BASE_CODE_PROTOCOL protocol if needed
   Status = ChangePxeState (BcInterface, FALSE, BcInterface->Mode->Started, FALSE);

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/PxeBaseCode/BlackBoxTest/PxeBaseCodeBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/PxeBaseCode/BlackBoxTest/PxeBaseCodeBBTestFunction.c
@@ -242,6 +242,7 @@ BBTestNewStartFunctionTest (
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
 
   UINT32                                Index;
   CHAR8                                 *TempPointer;
@@ -265,6 +266,13 @@ BBTestNewStartFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Disable EFI_PXE_BASE_CODE_PROTOCOL Protocol interface
@@ -991,6 +999,7 @@ BBTestNewSetIpFilterFunctionTest (
   EFI_STATUS                             Status;
   EFI_TEST_ASSERTION                     AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   EFI_PXE_BASE_CODE_IP_FILTER            BcIpFilter;
   UINT8                                  Index;
 
@@ -1014,6 +1023,13 @@ BBTestNewSetIpFilterFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Disable EFI_PXE_BASE_CODE_PROTOCOL Protocol interface
@@ -1198,7 +1214,8 @@ BBTestNewStopFunctionTest (
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
-  EFI_PXE_BASE_CODE_PROTOCOL           *BcInterface;
+  EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -1217,6 +1234,13 @@ BBTestNewStopFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Disable EFI_PXE_BASE_CODE_PROTOCOL Protocol interface
@@ -1340,7 +1364,8 @@ BBTestStartFunctionTest (
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
-  EFI_PXE_BASE_CODE_PROTOCOL           *BcInterface;
+  EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -1359,6 +1384,13 @@ BBTestStartFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   Status = ChangePxeState (BcInterface, FALSE, BcInterface->Mode->Started, FALSE);
   if (EFI_ERROR(Status)) {
@@ -1710,7 +1742,8 @@ BBTestStopFunctionTest (
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
-  EFI_PXE_BASE_CODE_PROTOCOL           *BcInterface;
+  EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -1729,6 +1762,13 @@ BBTestStopFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Enable EFI_PXE_BASE_CODE_PROTOCOL if needed
@@ -1783,7 +1823,8 @@ BBTestDhcpFunctionTest (
   EFI_TEST_LOGGING_LIBRARY_PROTOCOL     *LoggingLib;
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
-  EFI_PXE_BASE_CODE_PROTOCOL           *BcInterface;
+  EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   BOOLEAN                               ret;
 
   //
@@ -1813,6 +1854,13 @@ BBTestDhcpFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   // Enable EFI_PXE_BASE_CODE_PROTOCOL if needed
   Status = ChangePxeState (BcInterface, FALSE, BcInterface->Mode->Started, TRUE);
@@ -1917,7 +1965,8 @@ BBTestDiscoverFunctionTest (
   EFI_TEST_LOGGING_LIBRARY_PROTOCOL     *LoggingLib;
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
-  EFI_PXE_BASE_CODE_PROTOCOL           *BcInterface;
+  EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   UINT16                                Layer;
 
   //
@@ -1947,6 +1996,13 @@ BBTestDiscoverFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   Status = ReInitPxeBaseCode (BcInterface);
   if (EFI_ERROR(Status))
@@ -2057,6 +2113,7 @@ BBTestMtftpFunctionTest (
   EFI_INI_FILE_HANDLE                    FileHandle;
   EFI_STATUS                             Status;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   UINTN                                  FileSize;
   EFI_TEST_ASSERTION                     AssertionType;
@@ -2096,6 +2153,13 @@ BBTestMtftpFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   // Enable EFI_PXE_BASE_CODE_PROTOCOL protocol if needed
   Status = ChangePxeState (BcInterface, FALSE, BcInterface->Mode->Started, TRUE);
@@ -2240,6 +2304,7 @@ BBTestUdpWriteFunctionTest (
   EFI_INI_FILE_HANDLE                    FileHandle;
   EFI_STATUS                             Status;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_TEST_ASSERTION                    AssertionType;
 
@@ -2288,6 +2353,13 @@ BBTestUdpWriteFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Enable EFI_PXE_BASE_CODE_PROTOCOL if needed
@@ -2415,6 +2487,7 @@ BBTestUdpReadFunctionTest (
   EFI_INI_FILE_HANDLE                    FileHandle;
   EFI_STATUS                             Status;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   EFI_PXE_BASE_CODE_IP_FILTER            BcIpFilter;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_TEST_ASSERTION                     AssertionType;
@@ -2446,6 +2519,13 @@ BBTestUdpReadFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   // Re - initialize EFI_PXE_BASE_CODE_PROTOCOL
   Status = ReInitPxeBaseCode (BcInterface);
@@ -2585,6 +2665,7 @@ BBTestSetIpFilterFunctionTest (
   EFI_STATUS                             Status;
   EFI_TEST_ASSERTION                     AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   EFI_PXE_BASE_CODE_IP_FILTER            BcIpFilter;
 
   //
@@ -2605,6 +2686,13 @@ BBTestSetIpFilterFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Enable EFI_PXE_BASE_CODE_PROTOCOL if needed
@@ -2696,6 +2784,7 @@ BBTestArpFunctionTest (
   EFI_STATUS                             Status;
   EFI_TEST_ASSERTION                     AssertionType;
   EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   EFI_IP_ADDRESS                         IpAddr;
   EFI_MAC_ADDRESS                        MacAddr;
   EFI_SIMPLE_NETWORK_PROTOCOL            *SnpInterface;
@@ -2727,6 +2816,13 @@ BBTestArpFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   Status = ReInitPxeBaseCode (BcInterface);
   if (EFI_ERROR(Status)){
@@ -2938,7 +3034,8 @@ BBTestSetParametersFunctionTest (
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL    *StandardLib;
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
-  EFI_PXE_BASE_CODE_PROTOCOL           *BcInterface;
+  EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   BOOLEAN                               OrigAutoArp, NewAutoArp;
   UINT8                                 OrigTTL, NewTTL;
 
@@ -2960,6 +3057,13 @@ BBTestSetParametersFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Enable EFI_PXE_BASE_CODE_PROTOCOL if needed
@@ -3149,7 +3253,8 @@ BBTestSetStationIpFunctionTest (
   EFI_TEST_LOGGING_LIBRARY_PROTOCOL     *LoggingLib;
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
-  EFI_PXE_BASE_CODE_PROTOCOL           *BcInterface;
+  EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   EFI_IP_ADDRESS                        NewStationIp, NewSubnetMask;
 
   //
@@ -3179,6 +3284,13 @@ BBTestSetStationIpFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Enable EFI_PXE_BASE_CODE_PROTOCOL if needed
@@ -3280,7 +3392,8 @@ BBTestSetPacketsFunctionTest (
   EFI_STANDARD_TEST_LIBRARY_PROTOCOL   *StandardLib;
   EFI_STATUS                            Status;
   EFI_TEST_ASSERTION                    AssertionType;
-  EFI_PXE_BASE_CODE_PROTOCOL           *BcInterface;
+  EFI_PXE_BASE_CODE_PROTOCOL            *BcInterface;
+  UINT16                                *DevicePathStr;
   BOOLEAN                               NewDhcpDiscoverValid;
   BOOLEAN                               NewDhcpAckReceived;
   BOOLEAN                               NewProxyOfferReceived ;
@@ -3311,6 +3424,13 @@ BBTestSetPacketsFunctionTest (
   // Get the EFI_PXE_BASE_CODE_PROTOCOL Protocol interface to be tested
   //
   BcInterface = (EFI_PXE_BASE_CODE_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (BcInterface, &gBlackBoxEfiPxeBaseCodeProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   // Re-initialize the EFI_PXE_BASE_CODE_PROTOCOL
   Status = ReInitPxeBaseCode (BcInterface);

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTest.inf
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTest.inf
@@ -52,3 +52,4 @@
 
 [Protocols]
   gEfiTestLoggingLibraryGuid
+  gBlackBoxEfiSimpleNetworkProtocolGuid

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestConformance.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestConformance.c
@@ -53,7 +53,7 @@ BBTestStartConformanceTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
-
+  UINT16                                *DevicePathStr;
   //
   // Get the Standard Library Interface
   //
@@ -71,7 +71,13 @@ BBTestStartConformanceTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
-
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Check whether the state of network interface is EfiSimpleNetworkStarted.
   // If not, change the state to EfiSimpleNetworkStarted.
@@ -160,7 +166,7 @@ BBTestStopConformanceTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
-
+  UINT16                                *DevicePathStr;
   //
   // Get the Standard Library Interface
   //
@@ -178,7 +184,13 @@ BBTestStopConformanceTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
-
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Check whether the state of network interface is EfiSimpleNetworkStopped.
   // If not, change the state to EfiSimpleNetworkStopped.
@@ -266,7 +278,7 @@ BBTestInitializeConformanceTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
-
+  UINT16                                *DevicePathStr;
   //
   // Get the Standard Library Interface
   //
@@ -284,7 +296,13 @@ BBTestInitializeConformanceTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
-
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Check whether the state of network interface is EfiSimpleNetworkStopped.
   // If not, change the state to EfiSimpleNetworkStopped.
@@ -377,7 +395,7 @@ BBTestResetConformanceTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
-
+  UINT16                                *DevicePathStr;
   //
   // Get the Standard Library Interface
   //
@@ -395,7 +413,13 @@ BBTestResetConformanceTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
-
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Check whether the state of network interface is EfiSimpleNetworkStopped.
   // If not, change the state to EfiSimpleNetworkStopped.
@@ -488,7 +512,7 @@ BBTestShutdownConformanceTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
-
+  UINT16                                *DevicePathStr;
   //
   // Get the Standard Library Interface
   //
@@ -506,7 +530,13 @@ BBTestShutdownConformanceTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
-
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Check whether the state of network interface is EfiSimpleNetworkStopped.
   // If not, change the state to EfiSimpleNetworkStopped.
@@ -594,7 +624,7 @@ BBTestReceiveFilterConformanceTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_MAC_ADDRESS                       MAC;
-
+  UINT16                                *DevicePathStr;
   //
   // Get the Standard Library Interface
   //
@@ -612,7 +642,13 @@ BBTestReceiveFilterConformanceTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
-
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Check whether the state of network interface is EfiSimpleNetworkStopped.
   // If not, change the state to EfiSimpleNetworkStopped.
@@ -840,7 +876,7 @@ BBTestStationAddressConformanceTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
-
+  UINT16                                *DevicePathStr;
   //
   // Get the Standard Library Interface
   //
@@ -858,7 +894,13 @@ BBTestStationAddressConformanceTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
-
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Check whether the state of network interface is EfiSimpleNetworkStopped.
   // If not, change the state to EfiSimpleNetworkStopped.
@@ -988,7 +1030,7 @@ BBTestStatisticsConformanceTest (
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
   EFI_NETWORK_STATISTICS                StatisticsTable;
   UINTN                                 StatisticsSize;
-
+  UINT16                                *DevicePathStr;
   //
   // Get the Standard Library Interface
   //
@@ -1006,7 +1048,13 @@ BBTestStatisticsConformanceTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
-
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Check whether the state of network interface is EfiSimpleNetworkStopped.
   // If not, change the state to EfiSimpleNetworkStopped.
@@ -1164,7 +1212,7 @@ BBTestMCastIpToMacConformanceTest (
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
   EFI_IP_ADDRESS                        IP;
   EFI_MAC_ADDRESS                       MAC;
-
+  UINT16                                *DevicePathStr;
   //
   // Get the Standard Library Interface
   //
@@ -1182,7 +1230,13 @@ BBTestMCastIpToMacConformanceTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
-
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Check whether the state of network interface is EfiSimpleNetworkStopped.
   // If not, change the state to EfiSimpleNetworkStopped.
@@ -1279,6 +1333,7 @@ BBTestNVDataConformanceTest (
   EFI_SIMPLE_NETWORK_STATE              State1, State2, State3;
   VOID                                  *Buffer;
   UINT32                                CheckPoint1State;
+  UINT16                                *DevicePathStr;
   //
   // Get the Standard Library Interface
   //
@@ -1296,7 +1351,13 @@ BBTestNVDataConformanceTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
-
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Check whether the network interface support NvData if not return
   //
@@ -1525,6 +1586,7 @@ BBTestGetStatusConformanceTest (
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
   VOID                                  *TxBuf;
   UINT32                                InterruptStatus;
+  UINT16                                *DevicePathStr;
   //UINT32                                *pInterruptStatus;
 
   //
@@ -1544,7 +1606,13 @@ BBTestGetStatusConformanceTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
-
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Check whether the state of network interface is EfiSimpleNetworkStopped.
   // If not, change the state to EfiSimpleNetworkStopped.
@@ -1717,7 +1785,7 @@ BBTestTransmitConformanceTest (
   EFI_MAC_ADDRESS                       SrcAddr;
   EFI_MAC_ADDRESS                       DestAddr;
   UINT16                                Protocol;
-
+  UINT16                                *DevicePathStr;
   //
   // Get the Standard Library Interface
   //
@@ -1735,7 +1803,13 @@ BBTestTransmitConformanceTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
-
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Check whether the state of network interface is EfiSimpleNetworkStopped.
   // If not, change the state to EfiSimpleNetworkStopped.
@@ -1993,7 +2067,7 @@ BBTestReceiveConformanceTest (
   EFI_MAC_ADDRESS                       SrcAddr;
   EFI_MAC_ADDRESS                       DestAddr;
   UINT16                                Protocol;
-
+  UINT16                                *DevicePathStr;
   //
   // Get the Standard Library Interface
   //
@@ -2011,7 +2085,13 @@ BBTestReceiveConformanceTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
-
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
   //
   // Check whether the state of network interface is EfiSimpleNetworkStopped.
   // If not, change the state to EfiSimpleNetworkStopped.

--- a/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestFunction.c
+++ b/uefi-sct/SctPkg/TestCase/UEFI/EFI/Protocol/SimpleNetwork/BlackBoxTest/SimpleNetworkBBTestFunction.c
@@ -53,6 +53,7 @@ BBTestStartFunctionTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -71,6 +72,13 @@ BBTestStartFunctionTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Check whether the state of network interface is EfiSimpleNetworkStopped.
@@ -161,6 +169,7 @@ BBTestStopFunctionTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -179,6 +188,13 @@ BBTestStopFunctionTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Check whether the state of network interface is EfiSimpleNetworkStarted.
@@ -267,6 +283,7 @@ BBTestInitializeFunctionTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -285,6 +302,13 @@ BBTestInitializeFunctionTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Check whether the state of network interface is EfiSimpleNetworkStarted.
@@ -409,6 +433,7 @@ BBTestResetFunctionTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
+  UINT16                                *DevicePathStr;
   EFI_SIMPLE_NETWORK_MODE               Mode;
   UINT32                                InterruptStatus;
   VOID                                  *TxBuf;
@@ -434,6 +459,13 @@ BBTestResetFunctionTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Check whether the state of network interface is EfiSimpleNetworkInitialized.
@@ -597,6 +629,7 @@ BBTestShutdownFunctionTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
+  UINT16                                *DevicePathStr;
 
   //
   // Get the Standard Library Interface
@@ -615,6 +648,13 @@ BBTestShutdownFunctionTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Check whether the state of network interface is EfiSimpleNetworkInitialized.
@@ -705,6 +745,7 @@ BBTestReceiveFilterFunctionTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
+  UINT16                                *DevicePathStr;
   EFI_SIMPLE_NETWORK_MODE               Mode;
   EFI_MAC_ADDRESS                       MAC;
   UINT32                                ReceiveFilterMask;
@@ -728,6 +769,13 @@ BBTestReceiveFilterFunctionTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Check whether the state of network interface is EfiSimpleNetworkInitialized.
@@ -967,6 +1015,7 @@ BBTestStationAddressFunctionTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
+  UINT16                                *DevicePathStr;
   EFI_MAC_ADDRESS                       MacAddress;
   INTN                                  CheckPoint1, CheckPoint2;
   EFI_MAC_ADDRESS                       BackMacAddress;
@@ -988,6 +1037,13 @@ BBTestStationAddressFunctionTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Check whether the state of network interface is EfiSimpleNetworkInitialized.
@@ -1125,6 +1181,7 @@ BBTestStatisticsFunctionTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
+  UINT16                                *DevicePathStr;
   EFI_NETWORK_STATISTICS                StatisticsTable1;
   EFI_NETWORK_STATISTICS                StatisticsTable2;
   UINTN                                 StatisticsSize;
@@ -1160,6 +1217,13 @@ BBTestStatisticsFunctionTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Check whether the state of network interface is EfiSimpleNetworkInitialized.
@@ -1296,6 +1360,7 @@ BBTestMCastIpToMacFunctionTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
+  UINT16                                *DevicePathStr;
   EFI_IP_ADDRESS                        IP;
   EFI_MAC_ADDRESS                       MAC1;
   EFI_MAC_ADDRESS                       MAC2;
@@ -1317,6 +1382,13 @@ BBTestMCastIpToMacFunctionTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Check whether the state of network interface is EfiSimpleNetworkInitialized.
@@ -1432,6 +1504,7 @@ BBTestNVDataFunctionTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
+  UINT16                                *DevicePathStr;
   VOID                                  *Buffer;
   VOID                                  *Buffer1;
   VOID                                  *Buffer2;
@@ -1453,6 +1526,13 @@ BBTestNVDataFunctionTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Check whether the state of network interface is EfiSimpleNetworkInitialized.
@@ -1671,6 +1751,7 @@ BBTestGetStatusFunctionTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
+  UINT16                                *DevicePathStr;
   VOID                                  *TxBuf;
   UINT32                                InterruptStatus;
   EFI_STATUS                            StatCode;
@@ -1702,6 +1783,13 @@ BBTestGetStatusFunctionTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Check whether the state of network interface is EfiSimpleNetworkInitialized.
@@ -1969,6 +2057,7 @@ BBTestTransmitFunctionTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
+  UINT16                                *DevicePathStr;
   EFI_TEST_LOGGING_LIBRARY_PROTOCOL     *LoggingLib;
   VOID                                  *Buffer;
   UINTN                                 HeaderSize;
@@ -2015,6 +2104,13 @@ BBTestTransmitFunctionTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Check whether the state of network interface is EfiSimpleNetworkInitialized.
@@ -2247,6 +2343,7 @@ BBTestReceiveFunctionTest (
   EFI_TEST_ASSERTION                    AssertionType;
   EFI_SIMPLE_NETWORK_PROTOCOL           *SnpInterface;
   EFI_SIMPLE_NETWORK_STATE              State1, State2;
+  UINT16                                *DevicePathStr;
   EFI_TEST_LOGGING_LIBRARY_PROTOCOL     *LoggingLib;
   VOID                                  *Buffer;
   UINTN                                 HeaderSize;
@@ -2290,6 +2387,13 @@ BBTestReceiveFunctionTest (
   // Get the EFI_SIMPLE_NETWORK_PROTOCOL Protocol interface to be tested
   //
   SnpInterface = (EFI_SIMPLE_NETWORK_PROTOCOL *)ClientInterface;
+  DevicePathStr = SctDevicePathStrFromProtocol (SnpInterface, &gBlackBoxEfiSimpleNetworkProtocolGuid);
+  StandardLib->RecordMessage (
+                StandardLib,
+                EFI_VERBOSE_LEVEL_DEFAULT,
+                L"Device Path: %s\r\n",
+                DevicePathStr
+                );
 
   //
   // Check whether the state of network interface is EfiSimpleNetworkInitialized.


### PR DESCRIPTION
Tests Modified:
AdapterInfoBBTest
HIIConfigAccessBBTest
PxeBaseCodeBBTest
SimpleNetworkBBTest
Uses SctDevicePathStrFromProtocol function from DevicePath.c

UEFI-SCT
Cc: G Edhaya Chandran <Edhaya.Chandran@arm.com>
Cc: Barton Gao <gaojie@byosoft.com.cn>
Cc: Carolyn Gjertsen <Carolyn.Gjertsen@amd.com>
Cc: Samer El-Haj-Mahmoud <Samer.El-Haj-Mahmoud@arm.com>
Cc: Eric Jin <eric.jin@intel.com>
Cc: Arvin Chen <arvinx.chen@intel.com>
Cc: Supreeth Venkatesh <Supreeth.Venkatesh@amd.com>
Signed-off-by: Prachotan Bathi <prachotan.bathi@arm.com>